### PR TITLE
chore: Add binary path to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ __pycache__
 .history/
 .vscode/
 tmp
+
+# Binary
+poctl


### PR DESCRIPTION
`make poctl` creates a `poctl` binary 😬 