### PR TITLE
[DOCS] adding analyze service monitor docs

### DIFF
--- a/Documentation/commands/analyze/index.md
+++ b/Documentation/commands/analyze/index.md
@@ -1,0 +1,43 @@
+# Analyze Command
+
+The analyze command is used to examine Prometheus Operator objects to ensure they comply with specific rules. It checks whether the objects meet certain predefined conditions.
+
+```bash mdox-exec="go run main.go analyze --help" mdox-expect-exit-code=0
+Analyzes the given object and runs a set of rules on it to determine if it is compliant with the given rules.
+		For example:
+			- Analyze if the service monitor is selecting any service or using the correct service port.
+
+Usage:
+  poctl analyze [flags]
+
+Flags:
+  -h, --help               help for analyze
+  -k, --kind string        The kind of object to analyze. For example, ServiceMonitor
+  -n, --name string        The name of the object to analyze
+  -s, --namespace string   The namespace of the object to analyze
+
+Global Flags:
+      --kubeconfig string   path to the kubeconfig file, defaults to $KUBECONFIG
+      --log-format string   Log format (default "text")
+      --log-level string    Log level (default "DEBUG")
+```
+
+## Analyze ServiceMonitor
+
+The analyze command can specifically target a ServiceMonitor object within a Kubernetes cluster. Users can specify the namespace and name of the ServiceMonitor to assess its compliance with the predefined rules.
+
+## Rules
+
+The analyze command evaluates objects against a set of rules to determine compliance. These rules are defined in the `analyzer` package and are specifically implemented in the `internal/analyzer/servicemonitor.go` file.
+
+### ServiceMonitor Existence
+
+The ServiceMonitor object must exist in the Kubernetes cluster.
+
+### Selector Presence
+
+The ServiceMonitor object must have a defined selector that selects at least one service.
+
+### Port Matching
+
+Each endpoint within the ServiceMonitor object must have a defined port, and this port should match the port of the service it monitors.


### PR DESCRIPTION
This pull request introduces a new documentation section for the `analyze` command, which is used to examine Prometheus Operator objects for compliance with specific rules. The new documentation provides a detailed overview of the command's usage, flags, and specific rules for analyzing `ServiceMonitor` objects.

### Documentation updates:

* [`Documentation/commands/analyze/index.md`](diffhunk://#diff-975e48a917fb0aacf8b99f389b853b76ce598e680cf7cf369e4717b8313431deR1-R64): Added comprehensive documentation for the `analyze` command, including usage examples, flags, and specific rules for analyzing `ServiceMonitor` objects.