### PR TITLE
[DOCS] adding analyze operator cmd docs

### DIFF
--- a/Documentation/commands/analyze/index.md
+++ b/Documentation/commands/analyze/index.md
@@ -41,3 +41,21 @@ The ServiceMonitor object must have a defined selector that selects at least one
 ### Port Matching
 
 Each endpoint within the ServiceMonitor object must have a defined port, and this port should match the port of the service it monitors.
+
+## Analyze Operator
+
+The analyze command can also target the Prometheus Operator deployment within a Kubernetes cluster. Users can specify the namespace and name of the Prometheus Operator to assess its compliance with the predefined rules.
+
+## Rules
+
+The analyze command evaluates objects against a set of rules to determine compliance. These rules are defined in the `analyzer` package and are specifically implemented in the `internal/analyzer/operator.go` file.
+
+### Operator Existence
+
+The Prometheus Operator must be deployed in the Kubernetes cluster, which can be confirmed by checking for the presence of the prometheus-operator deployment in the specified namespace and under the given name.
+
+### RBAC Rules
+
+The Prometheus Operator deployment requires proper RBAC (Role-Based Access Control) rules to function correctly. This means the service account associated with the Prometheus Operator must have permissions aligned with the Prometheus Operator CRDs (Custom Resource Definitions) present in the cluster.
+
+For instance, if the Prometheus Operator is managing only Prometheus instances, the service account should have the necessary permissions to create, update, and delete Prometheus resources, but it should not have permissions to manage other resources like Alertmanager.


### PR DESCRIPTION
This pull request includes significant updates to the `Documentation/commands/analyze/index.md` file to enhance the documentation around the `analyze` command, particularly in the context of the Prometheus Operator. The most important changes include the addition of sections detailing the analyze command's functionality, the rules it evaluates, and specific requirements for the Prometheus Operator deployment.

### Enhancements to Documentation:

* **Analyze Operator Section**: Added a new section explaining how the `analyze` command can target the Prometheus Operator deployment within a Kubernetes cluster, including specifying the namespace and name of the Prometheus Operator. (`[Documentation/commands/analyze/index.mdR44-R61](diffhunk://#diff-975e48a917fb0aacf8b99f389b853b76ce598e680cf7cf369e4717b8313431deR44-R61)`)
* **Rules Section**: Introduced a section that outlines the rules evaluated by the `analyze` command, which are defined in the `analyzer` package and implemented in the `internal/analyzer/operator.go` file. (`[Documentation/commands/analyze/index.mdR44-R61](diffhunk://#diff-975e48a917fb0aacf8b99f389b853b76ce598e680cf7cf369e4717b8313431deR44-R61)`)
* **Operator Existence Rule**: Added a rule stating that the Prometheus Operator deployment must exist in the Kubernetes cluster. (`[Documentation/commands/analyze/index.mdR44-R61](diffhunk://#diff-975e48a917fb0aacf8b99f389b853b76ce598e680cf7cf369e4717b8313431deR44-R61)`)
* **RBAC Rules Section**: Detailed the RBAC (Role-Based Access Control) rules necessary for the Prometheus Operator deployment to function correctly, specifying the required permissions for the service account associated with the Prometheus Operator. (`[Documentation/commands/analyze/index.mdR44-R61](diffhunk://#diff-975e48a917fb0aacf8b99f389b853b76ce598e680cf7cf369e4717b8313431deR44-R61)`)