### PR TITLE
[DOCS] adding documentation link to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ go install github.com/prometheus-operator/poctl
 
 This project is currently in active development and fully experimental, so expect breaking changes and rough edges. We encourage you to try it out and provide feedback.
 
+## Documentation
+
+For detailed information on available commands and their usage, refer to the [Commands](Documentation/commands) documentation.
+
 ## Contributing
 
 See [CONTRIBUTING](https://github.com/prometheus-operator/prometheus-operator/blob/main/CONTRIBUTING.md).


### PR DESCRIPTION
This pull request includes a small change to the `README.md` file. The change adds a new section for documentation, providing a link to detailed information on available commands and their usage.

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R19-R22): Added a "Documentation" section with a link to the [Commands](Documentation/commands) documentation.