### PR TITLE
[CHORE] upgrading versions

### DIFF
--- a/Documentation/commands/create/index.md
+++ b/Documentation/commands/create/index.md
@@ -23,7 +23,7 @@ Global Flags:
       --kubeconfig string   path to the kubeconfig file, defaults to $KUBECONFIG
       --log-format string   Log format (default "text")
       --log-level string    Log level (default "DEBUG")
-      --version string      Prometheus Operator version (default "0.76.0")
+      --version string      Prometheus Operator version (default "0.78.2")
 ```
 
 # Create ServiceMonitor
@@ -46,5 +46,5 @@ Global Flags:
       --kubeconfig string   path to the kubeconfig file, defaults to $KUBECONFIG
       --log-format string   Log format (default "text")
       --log-level string    Log level (default "DEBUG")
-      --version string      Prometheus Operator version (default "0.76.0")
+      --version string      Prometheus Operator version (default "0.78.2")
 ```

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -26,7 +26,7 @@ var createCmd = &cobra.Command{
 	// Run: func(cmd *cobra.Command, args []string) { },
 }
 
-const LatestVersion = "0.76.0"
+const LatestVersion = "0.78.2"
 
 func init() {
 	rootCmd.AddCommand(createCmd)

--- a/internal/builder/kubeStateMetrics.go
+++ b/internal/builder/kubeStateMetrics.go
@@ -27,7 +27,7 @@ import (
 	"k8s.io/utils/ptr"
 )
 
-const LatestKubeStateMetricsVersion = "2.12.0"
+const LatestKubeStateMetricsVersion = "2.14.0"
 
 type KubeStateMetricsBuilder struct {
 	labels         map[string]string

--- a/internal/builder/nodeExporter.go
+++ b/internal/builder/nodeExporter.go
@@ -28,7 +28,7 @@ import (
 	"k8s.io/utils/ptr"
 )
 
-const LatestNodeExporterVersion = "1.8.1"
+const LatestNodeExporterVersion = "1.8.2"
 
 type NodeExporterBuilder struct {
 	labels         map[string]string


### PR DESCRIPTION
This pull request includes updates to version constants for several components in the codebase. The most important changes are:

Version updates:
* [`cmd/create.go`](diffhunk://#diff-e52f1f4fa0c533e3287cbe2ef0436582b5ca471a3fddcdf1f49fecd1ec0c7d13L29-R29): Updated `LatestVersion` constant from "0.76.0" to "0.78.2".
* [`internal/builder/kubeStateMetrics.go`](diffhunk://#diff-361365e122ed024ea9d443a531b6c57947c6dcc848756218e623fc426cc5143dL30-R30): Updated `LatestKubeStateMetricsVersion` constant from "2.12.0" to "2.14.0".
* [`internal/builder/nodeExporter.go`](diffhunk://#diff-ab1806d7ef43d327596d5d49d710a965a81cf93bbda75126d2bc2bc84bc9516dL31-R31): Updated `LatestNodeExporterVersion` constant from "1.8.1" to "1.8.2".